### PR TITLE
Turns city list into expandable cards

### DIFF
--- a/app/components/CityList.js
+++ b/app/components/CityList.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react'
 import IndividualCompany from './IndividualCompany'
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import { Card, CardActions, CardHeader, CardText } from 'material-ui/Card'
+import FlatButton from 'material-ui/FlatButton'
 
 export default class CityList extends Component {
   constructor(props) {
@@ -29,10 +32,18 @@ export default class CityList extends Component {
     })
 
     return(
-      <div className='citylist-container'>
-        <h1 className='city-name'>{this.props.city}</h1>
-        <div>{mappedCompanies}</div>
-      </div>
+    <MuiThemeProvider>
+      <Card className='citylist-container'>
+        <CardHeader
+          title={this.props.city}
+          actAsExpander={true}
+          showExpandableButton={true}
+        />
+        <CardText expandable={true}>
+          {mappedCompanies}
+        </CardText>
+      </Card>
+    </MuiThemeProvider>
     )
   }
 }


### PR DESCRIPTION
The city names now appear as a list of cities with an expandable button. When expanded, the companies belonging to that city appear in the expanded section.
![](http://g.recordit.co/nJM69xknYB.gif) 
Closes #76 