### PR TITLE
Add a sort of media query

### DIFF
--- a/app/components/HeroVideo/index.js
+++ b/app/components/HeroVideo/index.js
@@ -1,12 +1,13 @@
 import React from 'react'
 const video = require('./turing-loop-video.mp4') // move url loader into webpack.config
 
+
 const HeroVideo = () => {
   return(
     <div>
-      <video id="turing-video" className="video" loop autoPlay width="100%" >
+      <video id="turing-video" loop autoPlay width="100%" >
         <source src={ video } type="video/mp4" />
-        Your browser does not support HTML5 video. Here's a <a href="https://www.turing.io/sites/default/files/videos/turing-loop-video.mp4">link</a> to the video.
+        {/* Your browser does not support HTML5 video. Here's a <a href="https://www.turing.io/sites/default/files/videos/turing-loop-video.mp4">link</a> to the video. */}
       </video>
     </div>
   )

--- a/styles/App.scss
+++ b/styles/App.scss
@@ -53,16 +53,18 @@ body {
   width: 30px;
 }
 
-.video {
+#turing-video {
   position: absolute;
-  left: 50%;
-  z-index: -100;
-  transform: translate(-50%, -50%);
+  top: 0;
 }
 
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 1300px) {
+
+  #turing-video {
+    height: 700px;
+  }
 
   #footer {
-    margin-top: -25%;
+    margin-top: -5%;
   }
 }


### PR DESCRIPTION
@gprocell927 Take a look at the index.js file for the heroVideo.... does that url that I commented out exist because it's a fallback? If so, the relative path is working for me. I just commented it out because I didn't know what it was doing. We can comment it back in if it's a fallback thing. 

I'm a little confused around the whole thing. 

I made some minor adjustments to the media query. The video had both a class and and id that were being called, so i got rid of the class. It should stay looking nice until you get to about half the width of your computer screen. 